### PR TITLE
parse error near `>&' 

### DIFF
--- a/zsh-help.plugin.zsh
+++ b/zsh-help.plugin.zsh
@@ -10,7 +10,8 @@ if (($+commands[bat])); then
   }
   function -help-alias() {
     for opt in $@; do
-      alias -g -- "$opt=\\$opt 2>&1 | -help-"
+      # use |& instead of 2>&1 | to safely redirect stderr and stdout together
+      alias -g -- "$opt=\\$opt |& -help-"
     done
   }
   # llvm

--- a/zsh-help.plugin.zsh
+++ b/zsh-help.plugin.zsh
@@ -8,12 +8,20 @@ if (($+commands[bat])); then
   function -help-() {
     bat --color=always -pplhelp
   }
+
+  # Safe help wrapper to avoid global alias issues
+  # Usage: run-help ls
+  function run-help() {
+    "$@" --help 2>&1 | -help-
+  }
+
+  # Replaces the original -help-alias global alias system with safe aliases
   function -help-alias() {
     for opt in $@; do
-      # use |& instead of 2>&1 | to safely redirect stderr and stdout together
-      alias -g -- "$opt=\\$opt |& -help-"
+      alias -- "$opt=run-help"
     done
   }
+
   # llvm
   -help-alias --help --help-list --help-hidden --help-list-hidden -help -help-list -help-hidden -help-list-hidden
   # man
@@ -24,5 +32,6 @@ if (($+commands[bat])); then
   -help-alias --longhelp --fullhelp
   # gnome
   -help-alias --help-all --help-gapplication --help-gtk
+
   unfunction -- -help-alias
 fi


### PR DESCRIPTION
This addon is causing parse error near `>&' errors in other zsh addons
https://github.com/agkozak/zsh-z/issues/98
https://github.com/olets/zsh-abbr/issues/175

This line is the culprit:
`alias -g -- "$opt=\\$opt 2>&1 | -help-"`
This defines global aliases like:
`--help → \--help 2>&1 | -help-`
So now when a script (like zsh-job-queue.zsh) tries to do:
`"$(command cat /some/path)"`
And the contents of that file or a $var includes --help, it gets globally replaced with:
`--help 2>&1 | -help-`
Thus the parser sees something like:
`command cat somefile --help 2>&1 | -help-`
Which, inside quoted strings or command substitution, results in:
`parse error near '>&'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved help command aliases for safer and more consistent behavior without using global aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->